### PR TITLE
Fixed the operation.call() syntax

### DIFF
--- a/rtt/internal/AssignCommand.hpp
+++ b/rtt/internal/AssignCommand.hpp
@@ -80,12 +80,11 @@ namespace RTT
 
             bool execute()
             {
-                bool news = rhs->evaluate();
-                if (news) {
-                    lhs->set( rhs->rvalue() );
-                    return true;
-                }
-                return false;
+                // we ignore evaluate, which return value is legacy
+                // we always assign the current state of rhs
+                rhs->evaluate();
+                lhs->set( rhs->rvalue() );
+                return true;
             }
 
             void reset() {

--- a/rtt/scripting/CmdFunction.hpp
+++ b/rtt/scripting/CmdFunction.hpp
@@ -97,7 +97,7 @@ namespace RTT
         }
 
         virtual void reset() {
-            mrunner->removeFunction( _foo.get() );
+            if (_foo->isLoaded()) mrunner->removeFunction( _foo.get() );
             maccept = false;
             isqueued = false;
         }

--- a/rtt/scripting/ExpressionParser.cpp
+++ b/rtt/scripting/ExpressionParser.cpp
@@ -79,7 +79,7 @@ namespace RTT
 
   DataCallParser::DataCallParser( ExpressionParser& p, CommonParser& cp, TaskContext* c, ExecutionEngine* caller )
       : ret(), mhandle(), mcmdcnd(0), mobject(), mmethod(),
-        mcaller( caller ? caller : c->engine()), mis_send(false), mis_cmd(false), commonparser(cp), expressionparser( p ),
+        mcaller( caller ? caller : c->engine()), mcalltype(DEFAULT_CALLTYPE), commonparser(cp), expressionparser( p ),
         peerparser( c, cp, false ) // accept partial paths
   {
     BOOST_SPIRIT_DEBUG_RULE( datacall );
@@ -114,23 +114,19 @@ namespace RTT
     {
       std::string name( begin, end );
       if ( name == "send" ) {
-          mis_send = true;
-          mis_cmd  = false;
+          mcalltype = CALLTYPE_SEND;
           mmethod = mobject;
           mobject.clear();
       } else if (name == "cmd" ) {
-          mis_cmd = true;
-          mis_send = false;
+          mcalltype = CALLTYPE_CMD;
           mmethod = mobject;
           mobject.clear();
       } else if (name == "call" ) {
-          mis_send = false;
-          mis_cmd  = false;
+          mcalltype = CALLTYPE_CALL;
           mmethod = mobject;
           mobject.clear();
       } else {
-          mis_send = false;
-          mis_cmd  = false;
+          mcalltype = DEFAULT_CALLTYPE;
           mmethod = name;
       }
 //      cout << "seenmethodname "<< mobject << "." << mmethod<<endl;
@@ -147,7 +143,7 @@ namespace RTT
       if (true) {
           // it ain't...
           // set the proper object name again in case of a send()
-          if ( (mis_send || mis_cmd) && ops)
+          if ( (mcalltype != DEFAULT_CALLTYPE) && ops)
               mobject = ops->getName();
 //          cout << "DCP saw method "<< mmethod <<" of object "<<mobject<<" of peer "<<peer->getName()<<endl;
           // Check sanity of what we parsed:
@@ -232,24 +228,30 @@ namespace RTT
                 }
                 throw parse_exception_fatal_semantic_error( obj + "."+meth +": "+ obj +" is not a valid SendHandle object.");
             }
-            if (!mis_send && !mis_cmd) {
+
+            unsigned int arity = ops->getCollectArity(meth);
+            switch(mcalltype) {
+            case DEFAULT_CALLTYPE:
+            case CALLTYPE_CALL:
                 ret = ops->produce( meth, args, mcaller );
                 mhandle.reset();
-            } else if ( mis_send ){
+                break;
+            case CALLTYPE_SEND:
                 ret = ops->produceSend( meth, args, mcaller );
                 mhandle.reset( new SendHandleAlias( meth, ops->produceHandle(meth), ops->getPart(meth)) );
-            } else if ( mis_cmd ){
+                break;
+            case CALLTYPE_CMD:
                 ret = ops->produceSend( meth, args, mcaller );
                 args.clear();
                 args.push_back( ret ); // store the produceSend DS for collecting:
-                unsigned int arity = ops->getCollectArity(meth);
-                for ( int i =0; i != arity; ++i) {
+                for ( unsigned int i =0; i != arity; ++i) {
                     args.push_back( ops->getOperation(meth)->getCollectType( i + 1 )->buildValue() ); // this is only to satisfy produceCollect. We ignore the results...
                 }
                 ret = ops->produceCollect( meth, args, new ValueDataSource<bool>(false) ); // non-blocking, need extra condition:
                 DataSource<SendStatus>::shared_ptr dsss = boost::dynamic_pointer_cast<DataSource<SendStatus> >(ret);
                 assert(dsss);
                 mcmdcnd = new CmdCollectCondition( dsss ); // Replaces RTT 1.x completion condition.
+                break;
             }
         }
         catch( const wrong_number_of_args_exception& e )

--- a/rtt/scripting/ExpressionParser.hpp
+++ b/rtt/scripting/ExpressionParser.hpp
@@ -71,7 +71,7 @@ namespace RTT { namespace scripting
     std::string mobject;
     std::string mmethod;
     ExecutionEngine* mcaller;
-    bool mis_send, mis_cmd;
+    enum CallType { DEFAULT_CALLTYPE, CALLTYPE_CALL, CALLTYPE_SEND, CALLTYPE_CMD } mcalltype;
 
     rule_t datacall, arguments, peerpath, object, method;
 

--- a/rtt/scripting/ProgramGraphParser.cpp
+++ b/rtt/scripting/ProgramGraphParser.cpp
@@ -902,7 +902,7 @@ namespace RTT
       }
       else if ( conds.size() > 1) {
           cond = conds.front();
-          int i = 1;
+          unsigned int i = 1;
           while ( i != conds.size() ) {
               cond = new ConditionBinaryCompositeAND(cond, conds[i] );
               ++i;

--- a/rtt/scripting/SendHandleAlias.cpp
+++ b/rtt/scripting/SendHandleAlias.cpp
@@ -37,6 +37,8 @@
 
 
 #include "SendHandleAlias.hpp"
+#include <iostream>
+using namespace std;
 
 namespace RTT
 {
@@ -65,9 +67,12 @@ namespace RTT
     }
     SendHandleAlias* SendHandleAlias::copy(std::map<
             const base::DataSourceBase*, base::DataSourceBase*>& replacements,
-                                           bool)
+                                           bool inst)
     {
-        // instantiate does not apply.
+        // BIG NOTE: Instantiating a SendHandleAlias may/WILL happen too soon, not giving a chance
+        // to the arguments to instantiate during copy... Once instantiation is over, we 
+        // may call copy, but we guess this won't even happen in our current application.
+        assert( (inst == false) && "SendHandleAlias may not be instantiated !" );
         return new SendHandleAlias(mname, data->copy(replacements), fact);
     }
 

--- a/rtt/scripting/StateMachineService.cpp
+++ b/rtt/scripting/StateMachineService.cpp
@@ -43,6 +43,7 @@
 #include "../FactoryExceptions.hpp"
 #include "../TaskContext.hpp"
 #include "../OperationCaller.hpp"
+#include "SendHandleAlias.hpp"
 
 namespace RTT
 {
@@ -98,6 +99,17 @@ namespace RTT
             // while future methods for the original will still call the original.
             StateMachineServicePtr tmp( new StateMachineService( newsc, this->mtc ) );
             replacements[ _this.get() ] = tmp->_this.get(); // put 'newsc' in map
+
+            if (instantiate) {
+                // Remove any remaining SendHandleAlias attributes, since they are not allowed for an instantiate...
+                // See SendHandleAlias::copy() for more details.
+                for ( ConfigurationInterface::map_t::iterator it = values.begin(); it != values.end(); ++it) {
+                    if (dynamic_cast<SendHandleAlias*>(*it)) {
+                        values.erase(it);
+                        it = values.begin();
+                    }
+                }
+            }
 
             ConfigurationInterface* dummy = ConfigurationInterface::copy( replacements, instantiate );
             tmp->loadValues( dummy->getValues());


### PR DESCRIPTION
This pull request contains the latest cmd syntax patches from the [rdt-next-snrkiwi-add-send+cmd-to-scriptfunction](https://github.com/psoetens/rtt/tree/rdt-next-snrkiwi-add-send+cmd-to-scriptfunction) branch and one new commit that fixes the `.call()` syntax as already discussed. The goal is to merge your master-introduce-v1cmd-syntax to master sooner or later.

We should also consider to merge some other bug fixes related to scripting from the rdt-next branch to master before the toolchain 2.8 release:
- https://github.com/psoetens/rtt/commit/8d215d3b21366dd8c216d7a5b19836546853222f scripting: allow parsing of keywords at the end of a parse string.
- https://github.com/psoetens/rtt/commit/6537ae7736ba887c25642f76ac96081d04039c5e scripting: protect FSM execution and tracing against self-deactivation
- https://github.com/psoetens/rtt/commit/00b26794c31051b6710ccf7bad1ea393a9ebb6ca scripting: first check if we are still loaded before we try to remove ourselves
