### PR TITLE
Patches missing in the rdt-next-snrkiwi-add-send+cmd-to-scriptfunction branch?

### DIFF
--- a/rtt/base/ActivityInterface.hpp
+++ b/rtt/base/ActivityInterface.hpp
@@ -213,7 +213,9 @@ namespace RTT
 
         /**
          * Returns a pointer to the thread which will
-         * run this activity. Will not be null.
+         * run this activity. This can be null if the activity
+         * does not know its executing thread beforehand (e.g. for
+         * a SlaveActivity without a master).
          */
         virtual os::ThreadInterface* thread() = 0;
 

--- a/rtt/base/OperationCallerInterface.cpp
+++ b/rtt/base/OperationCallerInterface.cpp
@@ -47,3 +47,21 @@ void OperationCallerInterface::reportError() {
         this->myengine->setExceptionTask();
 }
 
+bool OperationCallerInterface::isSend() {
+    // ClientThread operations are never sent
+    if (met == ClientThread) return false;
+
+    // If we do not know on which engine will process the message. we better send it.
+    if (myengine == 0) return true;
+
+    // If the operation was called by ourselves, call it directly.
+    if (myengine == caller) return false;
+
+    // For example in case of master/slave activities, multiple engines can share one thread.
+    // In this case, even if the processor and caller engine is not the same, we still call if this thread is the same
+    // than the processor thread.
+    if (myengine != 0 && myengine->getThread() != 0 && myengine->getThread()->isSelf()) return false;
+
+    // otherwise, send it
+    return true;
+}

--- a/rtt/base/OperationCallerInterface.hpp
+++ b/rtt/base/OperationCallerInterface.hpp
@@ -76,7 +76,7 @@ namespace RTT
             /**
              * Helpful function to tell us if this operations is to be sent or not.
              */
-            bool isSend() { return met == OwnThread && myengine != caller; }
+            bool isSend();
 
             ExecutionEngine* getMessageProcessor() const;
 

--- a/rtt/extras/FileDescriptorActivity.cpp
+++ b/rtt/extras/FileDescriptorActivity.cpp
@@ -55,7 +55,9 @@
 #else
 #include <sys/select.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <errno.h>
+
 #endif
 
 #include <boost/cstdint.hpp>
@@ -63,9 +65,10 @@
 using namespace RTT;
 using namespace extras;
 using namespace base;
-const char FileDescriptorActivity::CMD_BREAK_LOOP;
-const char FileDescriptorActivity::CMD_TRIGGER;
-const char FileDescriptorActivity::CMD_UPDATE_SETS;
+const char FileDescriptorActivity::CMD_ANY_COMMAND;
+//const char FileDescriptorActivity::CMD_BREAK_LOOP;
+//const char FileDescriptorActivity::CMD_TRIGGER;
+//const char FileDescriptorActivity::CMD_UPDATE_SETS;
 
 
 /**
@@ -105,6 +108,9 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Runn
     , m_period(0)
     , m_has_error(false)
     , m_has_timeout(false)
+    , m_break_loop(false)
+    , m_trigger(false)
+    , m_update_sets(false)
 {
     FD_ZERO(&m_fd_set);
     FD_ZERO(&m_fd_work);
@@ -118,6 +124,9 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Seco
     , m_period(period >= 0.0 ? period : 0.0)        // intended period
     , m_has_error(false)
     , m_has_timeout(false)
+    , m_break_loop(false)
+    , m_trigger(false)
+    , m_update_sets(false)
 {
     FD_ZERO(&m_fd_set);
     FD_ZERO(&m_fd_work);
@@ -131,6 +140,9 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Seco
     , m_period(period >= 0.0 ? period : 0.0)        // intended period
     , m_has_error(false)
     , m_has_timeout(false)
+    , m_break_loop(false)
+    , m_trigger(false)
+    , m_update_sets(false)
 {
     FD_ZERO(&m_fd_set);
     FD_ZERO(&m_fd_work);
@@ -200,9 +212,10 @@ void FileDescriptorActivity::clearAllWatches()
 }
 void FileDescriptorActivity::triggerUpdateSets()
 {
-    // i works around warn_unused_result
-    int i = write(m_interrupt_pipe[1], &CMD_UPDATE_SETS, 1);
-    i = i;
+    { RTT::os::MutexLock lock(m_command_mutex);
+        m_update_sets = true;
+    }
+    write(m_interrupt_pipe[1], &CMD_ANY_COMMAND, 1);
 }
 bool FileDescriptorActivity::isUpdated(int fd) const
 { return FD_ISSET(fd, &m_fd_work); }
@@ -225,6 +238,27 @@ bool FileDescriptorActivity::start()
         return false;
     }
 
+#ifndef WIN32
+    // set m_interrupt_pipe to non-blocking
+    int flags = 0;
+    if ((flags = fcntl(m_interrupt_pipe[0], F_GETFL, 0)) == -1 ||
+        fcntl(m_interrupt_pipe[0], F_SETFL, flags | O_NONBLOCK) == -1 ||
+        (flags = fcntl(m_interrupt_pipe[1], F_GETFL, 0)) == -1 ||
+        fcntl(m_interrupt_pipe[1], F_SETFL, flags | O_NONBLOCK) == -1)
+    {
+        close(m_interrupt_pipe[0]);
+        close(m_interrupt_pipe[1]);
+        m_interrupt_pipe[0] = m_interrupt_pipe[1] = -1;
+        log(Error) << "FileDescriptorActivity: could not set the control pipe to non-blocking mode" << endlog();
+        return false;
+    }
+#endif
+
+    // reset flags
+    m_break_loop = false;
+    m_trigger = false;
+    m_update_sets = false;
+
     if (!Activity::start())
     {
         close(m_interrupt_pipe[0]);
@@ -238,9 +272,13 @@ bool FileDescriptorActivity::start()
 
 bool FileDescriptorActivity::trigger()
 { 
-    if (isActive() ) 
-        return write(m_interrupt_pipe[1], &CMD_TRIGGER, 1) == 1; 
-    else
+    if (isActive() ) {
+        { RTT::os::MutexLock lock(m_command_mutex);
+            m_trigger = true;
+        }
+        write(m_interrupt_pipe[1], &CMD_ANY_COMMAND, 1);
+        return true;
+    } else
         return false;
 }
 
@@ -252,7 +290,7 @@ struct fd_watch {
         if (fd != -1) 
             close(fd);
         fd = -1;
-    };
+    }
 };
 
 void FileDescriptorActivity::loop()
@@ -301,29 +339,17 @@ void FileDescriptorActivity::loop()
             m_has_timeout = true;
         }
 
-        bool do_break = false, do_trigger = true;
+        // Empty all commands queued in the pipe
         if (ret > 0 && FD_ISSET(pipe, &m_fd_work)) // breakLoop or trigger requests
-        { // Empty all commands queued in the pipe
-
+        {
             // These variables are used in order to loop with select(). See the
             // while() condition below.
             fd_set watch_pipe;
             timeval timeout;
-
-            do_trigger = false;
+            char dummy;
             do
             {
-                boost::uint8_t code;
-                if (read(pipe, &code, 1) == 1)
-                {
-                    if (code == CMD_BREAK_LOOP)
-                    {
-                        do_break = true;
-                    }
-                    else if (code == CMD_UPDATE_SETS){}
-                    else
-                        do_trigger = true;
-                }
+                read(pipe, &dummy, 1);
 
                 // Initialize the values for the next select() call
                 FD_ZERO(&watch_pipe);
@@ -332,9 +358,24 @@ void FileDescriptorActivity::loop()
                 timeout.tv_usec = 0;
             }
             while(select(pipe + 1, &watch_pipe, NULL, NULL, &timeout) > 0);
+        }
 
-            if (do_break)
+        // We check the flags after the command queue was emptied as we could miss commands otherwise:
+        bool do_trigger = true;
+        { RTT::os::MutexLock lock(m_command_mutex);
+            // This section should be really fast to not block threads calling trigger(), breakLoop() or watch().
+            if (m_trigger) {
+                do_trigger = true;
+                m_trigger = false;
+            }
+            if (m_update_sets) {
+                m_update_sets = false;
+                do_trigger = false;
+            }
+            if (m_break_loop) {
+                m_break_loop = false;
                 break;
+            }
         }
 
         if (do_trigger)
@@ -356,12 +397,10 @@ void FileDescriptorActivity::loop()
 
 bool FileDescriptorActivity::breakLoop()
 {
-    if (write(m_interrupt_pipe[1], &CMD_BREAK_LOOP, 1) != 1)
-        return false;
-
-    // either OS::SingleThread properly waits for loop() to return, or we are
-    // called from within loop() [for instance because updateHook() called
-    // fatal()]. In both cases, just return.
+    { RTT::os::MutexLock lock(m_command_mutex);
+        m_break_loop = true;
+    }
+    write(m_interrupt_pipe[1], &CMD_ANY_COMMAND, 1);
     return true;
 }
 

--- a/rtt/extras/FileDescriptorActivity.hpp
+++ b/rtt/extras/FileDescriptorActivity.hpp
@@ -114,9 +114,14 @@ namespace RTT { namespace extras {
         bool m_has_error;
         bool m_has_timeout;
 
-        static const char CMD_BREAK_LOOP  = 0;
-        static const char CMD_TRIGGER     = 1;
-        static const char CMD_UPDATE_SETS = 2;
+//        static const char CMD_BREAK_LOOP  = 0;
+//        static const char CMD_TRIGGER     = 1;
+//        static const char CMD_UPDATE_SETS = 2;
+        static const char CMD_ANY_COMMAND = 0;
+        RTT::os::Mutex m_command_mutex;
+        bool m_break_loop;
+        bool m_trigger;
+        bool m_update_sets;
 
         /** Internal method that makes sure loop() takes into account
          * modifications in the set of watched FDs

--- a/rtt/extras/SlaveActivity.cpp
+++ b/rtt/extras/SlaveActivity.cpp
@@ -37,7 +37,6 @@
 
 
 #include "SlaveActivity.hpp"
-#include "../os/MainThread.hpp"
 #include "Logger.hpp"
 
 namespace RTT {
@@ -91,7 +90,7 @@ namespace RTT {
 
     os::ThreadInterface* SlaveActivity::thread()
     {
-        return mmaster ? mmaster->thread() : os::MainThread::Instance();
+        return mmaster ? mmaster->thread() : 0;
     }
 
     base::ActivityInterface *SlaveActivity::getMaster() const

--- a/rtt/scripting/StateMachine.cpp
+++ b/rtt/scripting/StateMachine.cpp
@@ -1179,6 +1179,7 @@ namespace RTT {
             TRACE("Won't activate: already active.");
             return false;
         }
+        os::MutexLock lock(execlock);
 
         smpStatus = nill;
 
@@ -1244,9 +1245,10 @@ namespace RTT {
             currentTrans = 0;
         // if we stalled, in previous deactivate
         // even skip/stop exit program.
-        if ( next != 0 && current )
+        if ( next != 0 && current ) {
             leaveState( current );
-        else {
+            disableEvents(current);
+        } else {
             currentExit = 0;
             currentTrans = 0;
         }

--- a/tests/taskthread_test.cpp
+++ b/tests/taskthread_test.cpp
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE( testSlave )
     BOOST_CHECK( mtask.isPeriodic() == false );
     BOOST_CHECK( mtask.getPeriod() == 0.0 );
     BOOST_CHECK( mtask.execute() == false );
-    BOOST_CHECK( mtask.thread() == os::MainThread::Instance() );
+    BOOST_CHECK( mtask.thread() == 0 );
 
     // starting...
     BOOST_CHECK( mtask.start() == true );
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE( testSlave )
     BOOST_CHECK( mslave_p.isPeriodic() == true );
     BOOST_CHECK( mslave_p.getPeriod() == 0.001 );
     BOOST_CHECK( mslave_p.execute() == false );
-    BOOST_CHECK( mslave_p.thread() == os::MainThread::Instance() );
+    BOOST_CHECK( mslave_p.thread() == 0 );
 
     BOOST_CHECK( mslave_p.start() );
     BOOST_CHECK( r.init == true );


### PR DESCRIPTION
CC: @smits, @snrkiwi

What about those three patches which are not in the cleaned up rdt-next-snrkiwi-add-send+cmd-to-scriptfunction branch? They are not required to fix the master/slave state machine issues or for the new .cmd syntax but solve some other issues we observed during the last weeks and the work on top of rdt-next.

The blocking `FileDescriptorActivity::trigger()` method call is only a problem if the activity is triggered for more than 65536 times while one step is being executed. This could be a symptom of something else that went wrong and blocked the ExecutionEngine for too long, which has been fixed by the other patches in the meantime. If the component running with a FileDescriptorActivity is triggered frequently and its execution involves blocking calls or commands, then I would strongly recommend to use this patch as well.

The second patch fixes an OperationCaller's decision whether to call or send an operation directly depending on whether it would be executed by the same thread or not. This was kind of broken before in case of operation calls from slave to master components or vice-versa, where two ExecutionEngines share the same thread. In those cases the send() calls were enqueued and executed in the next cycle. With this patch, sending an operation that is owned by the master from the slave or vice-versa is executing the operation synchronously. I am still not sure if we really want this, as it somehow mixes the semantics of calling and sending. In my opinion, if the user sends an operation, it should always be executed in the next cycle even if the executor is the same thread. In this case we should only remove the `myengine != caller` check in `OperationCallerInterface::isSend()`.
Additionally, the patch changes the return of the MainThread as the default thread to SlaveActivities without an explicit master. @psoetens should review this before it would be merged.

The third patch fixes the missing `disableEvents()` call in `StateMachine::deactivate()` and adds a mutex lock to `StateMachine::activate()`.
