### PR TITLE
Moved portqueue from class TaskContext to the ExecutionEngine

### DIFF
--- a/rtt/DataFlowInterface.cpp
+++ b/rtt/DataFlowInterface.cpp
@@ -152,9 +152,9 @@ namespace RTT
         }
 #endif
         if (callback)
-            mservice->getOwner()->dataOnPortCallback(&port,callback); // the handle will be deleted when the port is removed.
+            mservice->getOwner()->setDataOnPortCallback(&port,callback); // the handle will be deleted when the port is removed.
         else
-            mservice->getOwner()->dataOnPortCallback(&port,boost::bind(&TaskCore::trigger, mservice->getOwner()) ); // default schedules an updateHook()
+            mservice->getOwner()->setDataOnPortCallback(&port,boost::bind(&TaskCore::trigger, mservice->getOwner()) ); // default schedules an updateHook()
 
 #ifndef ORO_SIGNALLING_PORTS
         port.signalInterface(true);
@@ -175,7 +175,7 @@ namespace RTT
                     mservice_ref = mservice->provides(); // uses shared_from_this()
                     mservice->removeService( name );
                     if (mservice->getOwner())
-                        mservice->getOwner()->dataOnPortRemoved( *it );
+                        mservice->getOwner()->removeDataOnPortCallback( *it );
                 }
                 (*it)->setInterface(0);
                 mports.erase(it);

--- a/rtt/ExecutionEngine.cpp
+++ b/rtt/ExecutionEngine.cpp
@@ -360,9 +360,15 @@ namespace RTT
         if (reason == RunnableInterface::Trigger) {
             /* Callback step */
             processMessages();
+            if ( taskc ) {
+                taskc->prepareUpdateHook();
+            }
         } else if (reason == RunnableInterface::TimeOut || reason == RunnableInterface::IOReady) {
             /* Update step */
             processMessages();
+            if ( taskc ) {
+                taskc->prepareUpdateHook();
+            }
             processFunctions();
             processHooks();
         }

--- a/rtt/ExecutionEngine.hpp
+++ b/rtt/ExecutionEngine.hpp
@@ -100,21 +100,16 @@ namespace RTT
          * between step()s or loop().
          *
          * @return true if the message got accepted, false otherwise.
-         * @return false when the MessageProcessor is not running or does not accept messages.
-         * @see acceptMessages
+         * @return false if the engine does not accept messages.
          */
         virtual bool process(base::DisposableInterface* c);
 
         /**
-         * Queue and execute (process) a given message. The message is
-         * executed in step() or loop() directly after all other
-         * queued ActionInterface objects. The constructor parameter
-         * \a queue_size limits how many messages can be queued in
-         * between step()s or loop().
+         * Queue and execute (process) a given port callback. The port callback is
+         * executed in step() or loop() directly after the queued messages.
          *
          * @return true if the port callback got accepted, false otherwise.
-         * @return false when the MessageProcessor is not running or does not accept messages.
-         * @see acceptMessages
+         * @return false if the engine does not accept messages.
          */
         virtual bool process(base::PortInterface* port);
 

--- a/rtt/ExecutionEngine.hpp
+++ b/rtt/ExecutionEngine.hpp
@@ -106,6 +106,19 @@ namespace RTT
         virtual bool process(base::DisposableInterface* c);
 
         /**
+         * Queue and execute (process) a given message. The message is
+         * executed in step() or loop() directly after all other
+         * queued ActionInterface objects. The constructor parameter
+         * \a queue_size limits how many messages can be queued in
+         * between step()s or loop().
+         *
+         * @return true if the port callback got accepted, false otherwise.
+         * @return false when the MessageProcessor is not running or does not accept messages.
+         * @see acceptMessages
+         */
+        virtual bool process(base::PortInterface* port);
+
+        /**
          * Run a given function in step() or loop(). The function may only
          * be destroyed after the
          * ExecutionEngine is stopped or removeFunction() was invoked. The number of functions the Processor can
@@ -238,6 +251,11 @@ namespace RTT
         internal::MWSRQueue<base::DisposableInterface*>* mqueue;
 
         /**
+         * The port callback queue
+         */
+        internal::MWSRQueue<base::PortInterface*>* port_queue;
+
+        /**
          * Stores all functions we're executing.
          */
         internal::MWSRQueue<base::ExecutableInterface*>* f_queue;
@@ -252,6 +270,7 @@ namespace RTT
         ExecutionEngine *mmaster;
 
         void processMessages();
+        void processPortCallbacks();
         void processFunctions();
         void processHooks();
 

--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -69,7 +69,6 @@ namespace RTT
 
     TaskContext::TaskContext(const std::string& name, TaskState initial_state /*= Stopped*/)
         :  TaskCore( initial_state)
-           ,portqueue( new MWSRQueue<PortInterface*>(64) )
            ,tcservice(new Service(name,this) ), tcrequests( new ServiceRequester(name,this) )
 #if defined(ORO_ACT_DEFAULT_SEQUENTIAL)
            ,our_act( new SequentialActivity( this->engine() ) )
@@ -143,7 +142,6 @@ namespace RTT
             }
             // Do not call this->disconnect() !!!
             // Ports are probably already destructed by user code.
-            delete portqueue;
         }
 
     bool TaskContext::connectPorts( TaskContext* peer )
@@ -422,39 +420,31 @@ namespace RTT
     void TaskContext::dataOnPort(PortInterface* port)
     {
         if ( this->dataOnPortHook(port) ) {
-            portqueue->enqueue( port );
-            this->getActivity()->trigger();
+            this->engine()->process(port);
         }
     }
 
-    bool TaskContext::dataOnPortHook( base::PortInterface* ) {
+    bool TaskContext::dataOnPortHook(PortInterface*) {
         return this->isRunning();
     }
 
-    void TaskContext::dataOnPortCallback(InputPortInterface* port, TaskContext::SlotFunction callback) {
+    void TaskContext::dataOnPortCallback(PortInterface* port) {
+        UserCallbacks::iterator it = user_callbacks.find(port);
+        if (it != user_callbacks.end() )
+            it->second(port); // fire the user callback
+    }
+
+    void TaskContext::setDataOnPortCallback(InputPortInterface* port, TaskContext::SlotFunction callback) {
         // user_callbacks will only be emitted from updateHook().
         MutexLock lock(mportlock);
         user_callbacks[port] = callback;
     }
 
-    void TaskContext::dataOnPortRemoved(PortInterface* port) {
+    void TaskContext::removeDataOnPortCallback(PortInterface* port) {
         MutexLock lock(mportlock);
         UserCallbacks::iterator it = user_callbacks.find(port);
         if (it != user_callbacks.end() ) {
             user_callbacks.erase(it);
-        }
-    }
-
-    void TaskContext::prepareUpdateHook()
-    {
-        if ( portqueue->isEmpty() )
-            return;
-        MutexLock lock(mportlock);
-        PortInterface* port = 0;
-        while ( portqueue->dequeue( port ) == true ) {
-            UserCallbacks::iterator it = user_callbacks.find(port);
-            if (it != user_callbacks.end() )
-                it->second(port); // fire the user callback
         }
     }
 }

--- a/rtt/TaskContext.hpp
+++ b/rtt/TaskContext.hpp
@@ -605,6 +605,22 @@ namespace RTT
          */
         virtual bool dataOnPortHook( base::PortInterface* port );
 
+        /**
+         * This method implements port callbacks. It will be called
+         * once per sample received on the port and is executed
+         * in the component's thread.
+         *
+         * The default implementation invokes the user callback
+         * if one was given in the addEventPort() call. It can be
+         * overwritten in a subclass to react on incoming data
+         * for all event ports. This is equivalent to adding this
+         * function as a user callback on each of the ports individually.
+         */
+        virtual void dataOnPortCallback( base::PortInterface* port );
+
+        // Required to invoke dataOnPortCallback() from the ExecutionEngine.
+        friend class ExecutionEngine;
+
     private:
 
         typedef std::map< std::string, TaskContext* > PeerMap;
@@ -632,7 +648,6 @@ namespace RTT
         void setup();
 
         friend class DataFlowInterface;
-        internal::MWSRQueue<base::PortInterface*>* portqueue;
         typedef std::map<base::PortInterface*, SlotFunction > UserCallbacks;
         UserCallbacks user_callbacks;
 
@@ -641,26 +656,16 @@ namespace RTT
          * event port.
          */
         void dataOnPort(base::PortInterface* port);
-        /**
-         * Called to inform us of the number of possible
-         * ports that will trigger a dataOnPort event.
-         * @return false if this->isRunning().
-         */
-        bool dataOnPortSize(unsigned int max);
+
         /**
          * Function to call in the thread of this component if data on the given port arrives.
          */
-        void dataOnPortCallback(base::InputPortInterface* port, SlotFunction callback);
+        void setDataOnPortCallback(base::InputPortInterface* port, SlotFunction callback);
+
         /**
          * Inform that a given port will no longer raise dataOnPort() events.
          */
-        void dataOnPortRemoved(base::PortInterface* port);
-
-        /**
-         * Function that is called before updateHook, where the TC implementation
-         * can do bookkeeping with regard to event ports.
-         */
-        void prepareUpdateHook();
+        void removeDataOnPortCallback(base::PortInterface* port);
 
         /**
          * Check if this component could provide a given service,

--- a/rtt/TaskContext.hpp
+++ b/rtt/TaskContext.hpp
@@ -632,24 +632,13 @@ namespace RTT
         void setup();
 
         friend class DataFlowInterface;
-        /**
-         * Helper class to store port callbacks
-         */
-        struct PortCallback : public base::DisposableInterface {
-            boost::function<void(void)> msf;
-            virtual void executeAndDispose() {
-                msf();
-            }
-            virtual void dispose() {}
-            virtual bool isError() const { return false;}
-        };
-        typedef std::map<base::PortInterface*, PortCallback > UserCallbacks;
+        internal::MWSRQueue<base::PortInterface*>* portqueue;
+        typedef std::map<base::PortInterface*, SlotFunction > UserCallbacks;
         UserCallbacks user_callbacks;
 
         /**
          * This callback is called each time data arrived on an
          * event port.
-         * @param port The port for which data arrived
          */
         void dataOnPort(base::PortInterface* port);
         /**
@@ -666,6 +655,12 @@ namespace RTT
          * Inform that a given port will no longer raise dataOnPort() events.
          */
         void dataOnPortRemoved(base::PortInterface* port);
+
+        /**
+         * Function that is called before updateHook, where the TC implementation
+         * can do bookkeeping with regard to event ports.
+         */
+        void prepareUpdateHook();
 
         /**
          * Check if this component could provide a given service,

--- a/rtt/base/TaskCore.cpp
+++ b/rtt/base/TaskCore.cpp
@@ -290,9 +290,6 @@ namespace RTT {
     void TaskCore::errorHook() {
     }
 
-    void TaskCore::prepareUpdateHook() {
-    }
-
     void TaskCore::updateHook()
     {
     }

--- a/rtt/base/TaskCore.cpp
+++ b/rtt/base/TaskCore.cpp
@@ -290,6 +290,9 @@ namespace RTT {
     void TaskCore::errorHook() {
     }
 
+    void TaskCore::prepareUpdateHook() {
+    }
+
     void TaskCore::updateHook()
     {
     }

--- a/rtt/base/TaskCore.hpp
+++ b/rtt/base/TaskCore.hpp
@@ -461,13 +461,6 @@ namespace RTT
         TaskCore( TaskCore& );
 
         friend class TaskContext;
-        /**
-         * This is how the EE informs the TaskContext that it is about
-         * to run updateHook. This function might be replaced by another
-         * mechanism in the future and currently serves to handle
-         * event ports callbacks.
-         */
-        virtual void prepareUpdateHook();
 
     protected:
         /**

--- a/rtt/base/TaskCore.hpp
+++ b/rtt/base/TaskCore.hpp
@@ -461,6 +461,14 @@ namespace RTT
         TaskCore( TaskCore& );
 
         friend class TaskContext;
+        /**
+         * This is how the EE informs the TaskContext that it is about
+         * to run updateHook. This function might be replaced by another
+         * mechanism in the future and currently serves to handle
+         * event ports callbacks.
+         */
+        virtual void prepareUpdateHook();
+
     protected:
         /**
          * Set to false in order to not trigger() when calling start().


### PR DESCRIPTION
This is an improved version of f266337, which solves the problem that operation calls and port callbacks could be interweaved unexpectedly.

A new method dataOnPortCallback(PortInterface*) has been added to the TaskContext interface which can be overridden in subclasses and which will be called exactly once per incoming sample on an EventPort by the ExecutionEngine.

The former internal methods `TaskContext::dataOnPortCallback()` and `TaskContext::dataOnPortRemoved()` methods for callback management have been renamed to `setDataOnPortCallback()` and `removeDataOnPortCallback()` for clarity.
