### PR TITLE
Split port queue from message queue in the ExecutionEngine

### DIFF
--- a/rtt/ExecutionEngine.cpp
+++ b/rtt/ExecutionEngine.cpp
@@ -72,6 +72,7 @@ namespace RTT
     ExecutionEngine::ExecutionEngine( TaskCore* owner )
         : taskc(owner),
           mqueue(new MWSRQueue<DisposableInterface*>(ORONUM_EE_MQUEUE_SIZE) ),
+          port_queue(new MWSRQueue<DisposableInterface*>(ORONUM_EE_MQUEUE_SIZE) ),
           f_queue( new MWSRQueue<ExecutableInterface*>(ORONUM_EE_MQUEUE_SIZE) ),
           mmaster(0)
     {
@@ -90,6 +91,7 @@ namespace RTT
             dis->dispose();
 
         delete f_queue;
+        delete port_queue;
         delete mqueue;
     }
 
@@ -224,6 +226,21 @@ namespace RTT
         msg_cond.broadcast(); // required for waitForMessages() (3rd party thread)
     }
 
+    void ExecutionEngine::processPortCallbacks()
+    {
+        // Fast bail-out :
+        if (port_queue->isEmpty())
+            return;
+
+        DisposableInterface* com(0);
+        {
+            while ( port_queue->dequeue(com) ) {
+                assert( com );
+                com->executeAndDispose();
+            }
+        }
+    }
+
     bool ExecutionEngine::process( DisposableInterface* c )
     {
         // forward message to master ExecutionEngine if available
@@ -242,6 +259,20 @@ namespace RTT
                 os::MutexLock lock(msg_lock);
                 msg_cond.broadcast(); // required for waitAndProcessMessages() (EE thread)
             }
+            return result;
+        }
+        return false;
+    }
+
+    bool ExecutionEngine::processPortCallback( DisposableInterface* c )
+    {
+        if ( c && this->getActivity() ) {
+            // We only reject running port callbacks when we're in the FatalError state.
+            if (taskc && taskc->mTaskState == TaskCore::FatalError )
+                return false;
+
+            bool result = port_queue->enqueue( c );
+            this->getActivity()->trigger();
             return result;
         }
         return false;
@@ -360,9 +391,11 @@ namespace RTT
         if (reason == RunnableInterface::Trigger) {
             /* Callback step */
             processMessages();
+            processPortCallbacks();
         } else if (reason == RunnableInterface::TimeOut || reason == RunnableInterface::IOReady) {
             /* Update step */
             processMessages();
+            processPortCallbacks();
             processFunctions();
             processHooks();
         }

--- a/rtt/ExecutionEngine.hpp
+++ b/rtt/ExecutionEngine.hpp
@@ -100,10 +100,18 @@ namespace RTT
          * between step()s or loop().
          *
          * @return true if the message got accepted, false otherwise.
-         * @return false when the MessageProcessor is not running or does not accept messages.
-         * @see acceptMessages
+         * @return false if the engine does not accept messages.
          */
         virtual bool process(base::DisposableInterface* c);
+
+        /**
+         * Queue and execute (process) a given port callback. The port callback is
+         * executed in step() or loop() directly after the queued messages.
+         *
+         * @return true if the port callback got accepted, false otherwise.
+         * @return false if the engine does not accept messages.
+         */
+        virtual bool processPortCallback(base::DisposableInterface* c);
 
         /**
          * Run a given function in step() or loop(). The function may only
@@ -238,6 +246,11 @@ namespace RTT
         internal::MWSRQueue<base::DisposableInterface*>* mqueue;
 
         /**
+         * The port callback queue
+         */
+        internal::MWSRQueue<base::DisposableInterface*>* port_queue;
+
+        /**
          * Stores all functions we're executing.
          */
         internal::MWSRQueue<base::ExecutableInterface*>* f_queue;
@@ -252,6 +265,7 @@ namespace RTT
         ExecutionEngine *mmaster;
 
         void processMessages();
+        void processPortCallbacks();
         void processFunctions();
         void processHooks();
 

--- a/rtt/TaskContext.hpp
+++ b/rtt/TaskContext.hpp
@@ -638,6 +638,7 @@ namespace RTT
         struct PortCallback : public base::DisposableInterface {
             boost::function<void(void)> msf;
             virtual void executeAndDispose() {
+                if (msf.empty()) return;
                 msf();
             }
             virtual void dispose() {}


### PR DESCRIPTION
Alternative implementation for #4, more along the lines of what we discussed yesterday.

This commit improves f26633764e3cff394206be5cd627ec795291d80c and solves
the problem that operation calls and port callbacks could be interweaved unexpectedly.

Furthermore, PortCallback instances are not removed from the user_callbacks map anymore,
but only invalidated by clearing the boost::function object, in order to prevent dangling
pointers in the callback queue.
