### PR TITLE
Run functions asynchronously in non-periodic tasks (fix #150)

### DIFF
--- a/rtt/Activity.cpp
+++ b/rtt/Activity.cpp
@@ -285,7 +285,7 @@ namespace RTT
             msg_cond.broadcast();
         }
 
-        if ( update_period == 0)
+        if (update_period == 0)
         {
             if ( inloop ) {
                 if ( !this->breakLoop() ) {
@@ -328,7 +328,7 @@ namespace RTT
     }
 
     bool Activity::isPeriodic() const {
-        return Thread::isPeriodic();
+        return Thread::isPeriodic() || (update_period != 0.0);
     }
 
     unsigned Activity::getCpuAffinity() const

--- a/rtt/ExecutionEngine.cpp
+++ b/rtt/ExecutionEngine.cpp
@@ -127,6 +127,8 @@ namespace RTT
                 return false;
             f->loaded(this);
             bool result = f_queue->enqueue( f );
+            // signal work is to be done:
+            this->getActivity()->trigger();
             return result;
         }
         return false;
@@ -408,6 +410,12 @@ namespace RTT
             /* Callback step */
             processMessages();
             processPortCallbacks();
+
+            // If this engine is run by a periodic activity, functions are only
+            // processed after a timeout (see below). Otherwise process as soon
+            // as possible.
+            if (!this->getActivity() || !this->getActivity()->isPeriodic()) processFunctions();
+
         } else if (reason == RunnableInterface::TimeOut || reason == RunnableInterface::IOReady) {
             /* Update step */
             processMessages();

--- a/rtt/extras/SlaveActivity.cpp
+++ b/rtt/extras/SlaveActivity.cpp
@@ -178,6 +178,8 @@ namespace RTT {
 
     bool SlaveActivity::isPeriodic() const
     {
+        if (mmaster)
+            return mmaster->isPeriodic();
         return mperiod != 0.0;
     }
     bool SlaveActivity::isActive() const
@@ -202,7 +204,7 @@ namespace RTT {
     bool SlaveActivity::execute()
     {
         // non periodic case.
-        if ( mperiod == 0.0 ) {
+        if ( !isPeriodic() ) {
             if ( !active || running )
                 return false;
             running = true;

--- a/rtt/scripting/CommandComposite.hpp
+++ b/rtt/scripting/CommandComposite.hpp
@@ -74,17 +74,17 @@ namespace RTT
             }
         }
 
-            /**
-             * Execute the functionality of all commands.
-             * Commands will be executed in the order they have been added
-             */
-            virtual bool execute() {
-            	for (std::vector<base::ActionInterface*>::iterator it=vect.begin();it!=vect.end();it++) {
-            		if ( !(*it)->execute() )
-                        return false;
-            	}
-                return true;
-			};
+        /**
+         * Execute the functionality of all commands.
+         * Commands will be executed in the order they have been added
+         */
+        virtual bool execute() {
+            for (std::vector<base::ActionInterface*>::iterator it=vect.begin();it!=vect.end();it++) {
+                if ( !(*it)->execute() )
+                    return false;
+            }
+            return true;
+        }
 
         void readArguments() {
             for (std::vector<base::ActionInterface*>::iterator it=vect.begin();it!=vect.end();it++)
@@ -105,7 +105,7 @@ namespace RTT
          */
         virtual void add(base::ActionInterface * com) {
             vect.push_back(com);
-        };
+        }
 
         virtual base::ActionInterface* clone() const
         {

--- a/tests/scripting_test.cpp
+++ b/tests/scripting_test.cpp
@@ -46,9 +46,9 @@ BOOST_AUTO_TEST_CASE(TestGetProvider)
     PluginLoader::Instance()->loadService("scripting",tc);
 
     // We use a sequential activity in order to force execution on trigger().
-    tc->stop();
-    BOOST_CHECK( tc->setActivity( new SequentialActivity() ) );
-    tc->start();
+//    tc->stop();
+//    BOOST_CHECK( tc->setActivity( new SequentialActivity() ) );
+//    tc->start();
 
     boost::shared_ptr<Scripting> sc = tc->getProvider<Scripting>("scripting");
     BOOST_REQUIRE( sc );
@@ -62,6 +62,7 @@ BOOST_AUTO_TEST_CASE(TestGetProvider)
 
     // executes our script in the EE:
     tc->getActivity()->trigger();
+    while(sc->isProgramRunning("Foo")) usleep(100);
 
     // test results:
     BOOST_CHECK( sc->isProgramRunning("Foo") == false );
@@ -75,9 +76,9 @@ BOOST_AUTO_TEST_CASE(TestScriptingParser)
     PluginLoader::Instance()->loadService("scripting",tc);
 
     // We use a sequential activity in order to force execution on trigger().
-    tc->stop();
-    BOOST_CHECK( tc->setActivity( new SequentialActivity() ) );
-    tc->start();
+//    tc->stop();
+//    BOOST_CHECK( tc->setActivity( new SequentialActivity() ) );
+//    tc->start();
 
     boost::shared_ptr<Scripting> sc = tc->getProvider<Scripting>("scripting");
     BOOST_REQUIRE( sc );
@@ -160,9 +161,9 @@ BOOST_AUTO_TEST_CASE(TestScriptingFunction)
     PluginLoader::Instance()->loadService("scripting",tc);
 
     // We use a sequential activity in order to force execution on trigger().
-    tc->stop();
-    BOOST_CHECK( tc->setActivity( new SequentialActivity() ) );
-    tc->start();
+//    tc->stop();
+//    BOOST_CHECK( tc->setActivity( new SequentialActivity() ) );
+//    tc->start();
 
     boost::shared_ptr<Scripting> sc = tc->getProvider<Scripting>("scripting");
     BOOST_REQUIRE( sc );
@@ -200,6 +201,34 @@ BOOST_AUTO_TEST_CASE(TestScriptingFunction)
     BOOST_CHECK_EQUAL( i, 0);
     BOOST_CHECK( GlobalService::Instance()->provides()->hasMember("gfunc1"));
 
+    // nested function:
+    statements="void func2(void) { func1(); }\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 0);
+    BOOST_CHECK( tc->provides("scripting")->hasMember("func2"));
+
+    // nested exported function:
+    statements="void efunc2(void) { efunc1(); }\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 0);
+    BOOST_CHECK( tc->provides("scripting")->hasMember("efunc2"));
+
+    // nested global function:
+    statements="void gfunc2(void) { gfunc1(); }\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 0);
+    BOOST_CHECK( tc->provides("scripting")->hasMember("gfunc2"));
+
+    // nested local function:
+    statements="void lfunc2(void) { lfunc1(); }\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 0);
+    BOOST_CHECK( tc->provides("scripting")->hasMember("lfunc2"));
+
     // invoke a function:
     statements="func1()\n";
     r = sc->eval(statements);
@@ -224,55 +253,77 @@ BOOST_AUTO_TEST_CASE(TestScriptingFunction)
     BOOST_CHECK( r );
     BOOST_CHECK_EQUAL( i, 4);
 
+    // invoke a nested function:
+    statements="func2()\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 5);
+
+    // invoke a nested exported function:
+    statements="efunc2()\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 6);
+
+    // invoke a nested global function:
+    statements="gfunc2()\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 7);
+
+    // invoke a nested local function:
+    statements="lfunc2()\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 8);
+
     // call a function:
     statements="call func1()\n";
     r = sc->eval(statements);
     BOOST_CHECK( !r );
-    BOOST_CHECK_EQUAL( i, 4);
+    BOOST_CHECK_EQUAL( i, 8);
 
     // call an exported function:
     statements="call efunc1()\n";
     r = sc->eval(statements);
     BOOST_CHECK( !r );
-    BOOST_CHECK_EQUAL( i, 4);
+    BOOST_CHECK_EQUAL( i, 8);
 
     // RE-define a function (added to scripting interface):
     statements="void func1(void) { test.increase(); test.increase(); }\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
-    BOOST_CHECK_EQUAL( i, 4);
+    BOOST_CHECK_EQUAL( i, 8);
     BOOST_CHECK( tc->provides("scripting")->hasMember("func1"));
 
     statements="func1()\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
-    BOOST_CHECK_EQUAL( i, 6);
+    BOOST_CHECK_EQUAL( i, 10);
 
     // RE-export a function:
     statements="export void efunc1(void) { test.increase(); test.increase();}\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
-    BOOST_CHECK_EQUAL( i, 6);
+    BOOST_CHECK_EQUAL( i, 10);
     BOOST_CHECK( tc->provides()->hasMember("efunc1"));
 
     statements="efunc1()\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
-    BOOST_CHECK_EQUAL( i, 8);
+    BOOST_CHECK_EQUAL( i, 12);
 
     // RE-global a function:
     statements="global void gfunc1(void) { test.increase(); test.increase();}\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
-    BOOST_CHECK_EQUAL( i, 8);
+    BOOST_CHECK_EQUAL( i, 12);
     BOOST_CHECK( GlobalService::Instance()->provides()->hasMember("gfunc1"));
 
     statements="gfunc1()\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
-    BOOST_CHECK_EQUAL( i, 10);
-
-
+    BOOST_CHECK_EQUAL( i, 14);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This commit partially reverts the changes introduced in orocos-toolchain/rtt#91.

The scripting_test is modified so that it would block indefinitely for the same reason as for the example script in #150 by bot using a SequentialActivity. The nested function calls are not strictly required. The test would already fail as is without the SequentialActivity.

TODO: update documentation (see 047f92d6969700a12a59f414528f017bacb13d7f)
