### PR TITLE
Clear the task's provided and required service interface during destruction

### DIFF
--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -124,6 +124,7 @@ namespace RTT
             // here would only lead to calling invalid virtual functions.
             // [Rule no 1: Don't call virtual functions in a destructor.]
             // [Rule no 2: Don't call virtual functions in a constructor.]
+            this->clear();
 
             // these need to be freed before we cleanup the EE:
             localservs.clear();


### PR DESCRIPTION
This PR will hopefully fix https://github.com/orocos-toolchain/rtt/issues/179. This bug was a regression from the removal of the clear() call in 42a62e8d7b81cebcf9c34e012b339a302c200033.

@psoetens, do you remember why the `clear()` call has been removed? All unit tests pass successfully.
